### PR TITLE
fix(core): fix memory leak on application reference destroy

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -564,6 +564,10 @@ export class ApplicationRef {
   private _unloadComponent(componentRef: ComponentRef<any>): void {
     this.detachView(componentRef.hostView);
     remove(this.components, componentRef);
+    const testabilityRegistry = componentRef.injector.get(TestabilityRegistry, null);
+    if (testabilityRegistry) {
+      testabilityRegistry.unregisterApplication(componentRef.location.nativeElement);
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
When an application reference is destroyed it stays in memory because it is still registered in the testability registry.

Closes #22106, #13725

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
